### PR TITLE
Add wrapper for `MouseMoveToPos()` and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImGuiTestEngine"
 uuid = "464e2eba-0a11-4ed3-b274-413caa1a1cca"
 authors = ["JamesWrigley <james@puiterwijk.org>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 CImGui = "5d785b6c-b76f-510e-a07c-3070796c7e87"
@@ -14,7 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CImGui = "2,3,4"
-CImGuiPack_jll = "0.3,0.4,0.5,0.6,0.7"
+CImGuiPack_jll = "0.7.1"
 Compat = "4.15.0"
 CxxWrap = "0.16.0"
 DocStringExtensions = "0.9.3"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Changelog = "5217a498-cd5d-4ec6-b8c2-9b85a09b6e3e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DocumenterInterLinks = "d12716ef-a0f6-4df4-a9f1-a5a34e75c656"
 ImGuiTestEngine = "464e2eba-0a11-4ed3-b274-413caa1a1cca"
 LiveServer = "16fef848-5104-11e9-1b77-fb7a48bbb589"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,8 @@ import Revise
 import Documenter: Remotes, HTML, makedocs, deploydocs
 import Changelog
 import ImGuiTestEngine
+import DocumenterInterLinks: InterLinks
+
 
 # Explicitly call Revise to update changes to the docstrings
 Revise.revise()
@@ -14,6 +16,10 @@ Changelog.generate(
     repo="JuliaImGui/ImGuiTestEngine.jl"
 )
 
+links = InterLinks(
+    "CImGui" => "https://juliaimgui.github.io/ImGuiDocs.jl/cimgui/stable/"
+)
+
 makedocs(;
          repo = Remotes.GitHub("JuliaImGui", "ImGuiTestEngine.jl"),
          sitename = "ImGuiTestEngine",
@@ -23,7 +29,8 @@ makedocs(;
              "api.md",
              "changelog.md"
          ],
-         modules = [ImGuiTestEngine]
+         modules = [ImGuiTestEngine],
+         plugins = [links]
          )
 
 deploydocs(; repo="github.com/JuliaImGui/ImGuiTestEngine.jl.git")

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,11 @@ CurrentModule = ImGuiTestEngine
 This documents notable changes in ImGuiTestEngine.jl. The format is based on
 [Keep a Changelog](https://keepachangelog.com).
 
+## [v0.1.6] - 2025-02-01
+
+### Added
+- Bindings for [`MouseMoveToPos()`](@ref) ([#12]).
+
 ## [v0.1.5] - 2024-12-19
 
 Patch release to actually add compat for CImGui v4 ([#9]).

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -114,6 +114,13 @@ same thing as `SetRef("My window")`.
     te.lib.Thing(ctx, te.lib.ImGuiTestRef("my ref"))
     ```
 
+    For functions that take an `ImVec2` argument, create one that can be passed
+    to the C++ functions with the un-exported `mkImVec2()` helper function like
+    so:
+    ```julia
+    te.lib.Thing(ctx, te.mkImVec2(x, y))
+    ```
+
 ```@docs
 TestContext
 @imcheck
@@ -122,6 +129,7 @@ SetRef
 GetRef
 MouseClick
 MouseMove
+MouseMoveToPos
 ItemOpen
 ItemClose
 OpenAndClose

--- a/src/ImGuiTestEngine.jl
+++ b/src/ImGuiTestEngine.jl
@@ -10,7 +10,7 @@ export @register_test, @imcheck, @imcheck_noret,
     ItemClick, ItemDoubleClick, ItemCheck, ItemOpen, ItemClose,
     MenuClick,
     ComboClick, ComboClickAll,
-    MouseClick, MouseMove,
+    MouseClick, MouseMove, MouseMoveToPos,
     Yield,
     OpenAndClose
 

--- a/src/context.jl
+++ b/src/context.jl
@@ -61,6 +61,9 @@ function _generate_imcheck(expr, source, with_return, kwargs...)
     end
 end
 
+# Helper function to create a C++-wrapped ImVec2
+mkImVec2(x, y) = lib.mkImVec2(convert(Float32, x), convert(Float32, y))
+
 """
     @imcheck expr
 
@@ -336,6 +339,33 @@ function MouseMove(test_ref::TestRef, ctx=nothing)
     @_default_ctx
     lib.MouseMove(ctx, lib.ImGuiTestRef(test_ref))
 end
+
+"""
+$(TYPEDSIGNATURES)
+
+Move the mouse to the given position in absolute coordinates (e.g. matching
+[`ig.GetMousePos()`](@extref `CImGui.GetMousePos`) and
+[`ig.GetCursorScreenPos()`](@extref `CImGui.GetCursorScreenPos`)).
+
+# Examples
+```julia
+@register_test(engine, "foo", "bar") do ctx
+    MouseMoveToPos(100, 100)
+    MouseMoveToPos((100, 100))
+    MouseMoveToPos(ig.ImVec2(100, 100))
+end
+```
+"""
+function MouseMoveToPos(x, y, ctx=nothing)
+    @_default_ctx
+    lib.MouseMoveToPos(ctx, mkImVec2(x, y))
+end
+
+"$(TYPEDSIGNATURES)"
+MouseMoveToPos(pos::ig.ImVec2, ctx=nothing) = MouseMoveToPos(pos.x, pos.y, ctx)
+
+"$(TYPEDSIGNATURES)"
+MouseMoveToPos(pos::NTuple{2, Real}, ctx=nothing) = MouseMoveToPos(pos[1], pos[2], ctx)
 
 """
 $(TYPEDSIGNATURES)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -386,6 +386,26 @@ end
                 @imcheck is_hovered
             end
 
+            mouse_pos = nothing
+            t = @register_test(engine, "Context", "MouseMoveToPos")
+            t.GuiFunc = ctx -> begin
+                ig.Begin("Window")
+
+                mouse_pos = ig.GetMousePos()
+                ig.Text("Cursor position: ($(mouse_pos.x), $(mouse_pos.y))")
+                ig.End()
+            end
+            t.TestFunc = ctx -> begin
+                SetRef("Window")
+
+                MouseMoveToPos(100, 100)
+                @imcheck mouse_pos.x == mouse_pos.y == 100
+                MouseMoveToPos(ig.ImVec2(200, 200))
+                @imcheck mouse_pos.x == mouse_pos.y == 200
+                MouseMoveToPos((300, 300))
+                @imcheck mouse_pos.x == mouse_pos.y == 300
+            end
+
             ig.render(ctx; engine) do ; end
         end
     end


### PR DESCRIPTION
This required bumping the JLL compat version to the one with `mkImVec2()`.

Fixes #11, depends on https://github.com/JuliaPackaging/Yggdrasil/pull/10399.