### PR TITLE
Fix UndefVarError(ImVec2) in generated pOut wrappers

### DIFF
--- a/gen/generator.jl
+++ b/gen/generator.jl
@@ -673,6 +673,7 @@ function generate()
                   const VoidablePtrOrRef{T} = Union{Ptr{T}, Ref{T}, Ptr{Cvoid}} where T
 
                   const TestRef = Union{String, Int, lib.ImGuiTestRef}
+                  const ImVec2 = libig.ImVec2
 
                   """)
 

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -2,6 +2,7 @@ const PtrOrRef{T} = Union{Ptr{T},Ref{T}} where {T}
 const VoidablePtrOrRef{T} = Union{Ptr{T},Ref{T},Ptr{Cvoid}} where {T}
 
 const TestRef = Union{String,Int,lib.ImGuiTestRef}
+const ImVec2 = libig.ImVec2
 
 const ImGuiCaptureImageBuf = lib.ImGuiCaptureImageBuf
 const ImGuiCaptureArgs = lib.ImGuiCaptureArgs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -249,6 +249,18 @@ end
                 @imcheck te.GetWindowByRef("Nope") == C_NULL
             end
 
+            t = @register_test(engine, "Context", "pOut wrappers returning ImVec2")
+            t.GuiFunc = () -> begin
+                ig.Begin("Titlebar")
+                ig.End()
+            end
+            t.TestFunc = () -> begin
+                @imcheck te.GetWindowTitlebarPoint("Titlebar") isa ig.ImVec2
+                @imcheck te.GetPosOnVoid(ig.GetMainViewport()) isa ig.ImVec2
+                @imcheck te.GetMainMonitorWorkPos() isa ig.ImVec2
+                @imcheck te.GetMainMonitorWorkSize() isa ig.ImVec2
+            end
+
             menu_item_selected = false
             t = @register_test(engine, "Context", "MenuClick")
             t.GuiFunc = () -> begin


### PR DESCRIPTION
**Depends on #19.** Branched off `aarch64-darwin-static-cfunc`, so until #19 merges the diff shows all 6 commits; only the last two belong here. Diff cleans up automatically once #19 lands.

`ImGuiTestEngine.GetWindowTitlebarPoint("any-window")` (and `GetPosOnVoid` / `GetMainMonitorWorkPos` / `GetMainMonitorWorkSize`) throws `UndefVarError: `ImVec2` not defined in `ImGuiTestEngine`` — `src/wrapper.jl` emits a bare `Ref{ImVec2}()` and `ImVec2` isn't bound at the wrapper module's scope. Bug pre-dates #19 — same four sites exist on `master`.

Root cause: the `renamer` in `gen/generator.jl` rewrites `Im*` symbols inside function-call args (`@capture(x, f_(args__))`) but skips curly type expressions like `Ref{ImVec2}`. The pOut boilerplate splices the raw ccall type into a curly, so the renamer never qualifies it.

Fix: symmetric `elseif @capture(x, T_{params__})` branch with the same rewrite. Regenerating gives `Ref{libig.ImVec2}()` at the 4 load-bearing sites plus 16 cosmetic `Ref{ImGuiTestRef}` → `Ref{lib.ImGuiTestRef}` rewrites (functionally identical via the existing top-of-file aliases).