### PR TITLE
Fix ItemInfo struct layout (ImGuiTestItemInfo bitfields)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 CEnum = "0.5.0"
 CImGui = "8"
-CImGuiPack_jll = "0.12.1"
+CImGuiPack_jll = "0.12.2"
 DocStringExtensions = "0.9.3"
 ScopedValues = "1.2.1"
 Test = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImGuiTestEngine"
 uuid = "464e2eba-0a11-4ed3-b274-413caa1a1cca"
 authors = ["JamesWrigley <james@puiterwijk.org>"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImGuiTestEngine"
 uuid = "464e2eba-0a11-4ed3-b274-413caa1a1cca"
 authors = ["JamesWrigley <james@puiterwijk.org>"]
-version = "1.0.4"
+version = "1.1.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -14,6 +14,10 @@ This documents notable changes in ImGuiTestEngine.jl. The format is based on
 - A per-frame post-swap hook (`CImGui._post_swap`) is now defined for `Engine` so the GLFW backend can advance screen-capture and video-capture state ([#19]).
 ### Changed
 - Updated for ImGui 1.92.8 / ImPlot 1.0 ([#18]).
+- Bumped the minimum supported Julia version to 1.10 ([#21]).
+### Fixed
+- Fixed an `UndefVarError` for `ImVec2` when calling pOut wrappers that return an `ImVec2` (e.g. `GetWindowTitlebarPoint()`, `GetPosOnVoid()`) ([#20]).
+- Fixed `ItemInfo()` returning a wrong `RectFull` (and other shifted fields): the `ImGuiTestItemInfo` C++ bitfields (`NavLayer`/`Depth`) are now reflected in the generated struct layout. ([#22]).
 
 ## [v1.0.3] - 2026-01-05
 

--- a/gen/generator.toml
+++ b/gen/generator.toml
@@ -12,7 +12,7 @@ output_ignorelist = [
 
 auto_mutability = true
 auto_mutability_with_new = false
-auto_mutability_ignorelist = ["ImGuiTestRef", "ImGuiTestRefDesc", "ImGuiTestEngineResultSummary"]
+auto_mutability_ignorelist = ["ImGuiTestRef", "ImGuiTestRefDesc", "ImGuiTestEngineResultSummary", "ImGuiTestGenericVars"]
 auto_mutability_includelist = ["ImGuiTestCoroutineInterface"]
 
 [codegen]

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -247,39 +247,75 @@ end
 
 
 struct ImGuiTestItemInfo
-    ID::Cuint
-    DebugLabel::NTuple{32, Cchar}
-    Window::Ptr{ImGuiWindow}
-    NavLayer::Cuint
-    Depth::Cint
-    TimestampMain::Cint
-    TimestampStatus::Cint
-    ParentID::Cuint
-    RectFull::ImRect
-    RectClipped::ImRect
-    ItemFlags::Cint
-    StatusFlags::Cint
+    data::NTuple{96, UInt8}
 end
+
 function Base.getproperty(x::Ptr{ImGuiTestItemInfo}, f::Symbol)
     f === :ID && return Ptr{Cuint}(x + 0)
     f === :DebugLabel && return Ptr{NTuple{32, Cchar}}(x + 4)
     f === :Window && return Ptr{Ptr{ImGuiWindow}}(x + 36)
-    f === :NavLayer && return Ptr{Cuint}(x + 40)
-    f === :Depth && return Ptr{Cint}(x + 44)
-    f === :TimestampMain && return Ptr{Cint}(x + 48)
-    f === :TimestampStatus && return Ptr{Cint}(x + 52)
-    f === :ParentID && return Ptr{Cuint}(x + 56)
-    f === :RectFull && return Ptr{ImRect}(x + 60)
-    f === :RectClipped && return Ptr{ImRect}(x + 76)
-    f === :ItemFlags && return Ptr{Cint}(x + 92)
-    f === :StatusFlags && return Ptr{Cint}(x + 96)
+    f === :NavLayer && return (Ptr{Cuint}(x + 40), 0, 1)
+    f === :Depth && return (Ptr{Cint}(x + 40), 1, 16)
+    f === :TimestampMain && return Ptr{Cint}(x + 44)
+    f === :TimestampStatus && return Ptr{Cint}(x + 48)
+    f === :ParentID && return Ptr{Cuint}(x + 52)
+    f === :RectFull && return Ptr{ImRect}(x + 56)
+    f === :RectClipped && return Ptr{ImRect}(x + 72)
+    f === :ItemFlags && return Ptr{Cint}(x + 88)
+    f === :StatusFlags && return Ptr{Cint}(x + 92)
     return getfield(x, f)
 end
 
-function Base.setproperty!(x::Ptr{ImGuiTestItemInfo}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
+function Base.getproperty(x::ImGuiTestItemInfo, f::Symbol)
+    r = Ref{ImGuiTestItemInfo}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiTestItemInfo}, r)
+    fptr = getproperty(ptr, f)
+    begin
+        if fptr isa Ptr
+            return GC.@preserve(r, unsafe_load(fptr))
+        else
+            (baseptr, offset, width) = fptr
+            ty = eltype(baseptr)
+            baseptr32 = convert(Ptr{UInt32}, baseptr)
+            u64 = GC.@preserve(r, unsafe_load(baseptr32))
+            if offset + width > 32
+                u64 |= GC.@preserve(r, unsafe_load(baseptr32 + 4)) << 32
+            end
+            u64 = u64 >> offset & (1 << width - 1)
+            return u64 % ty
+        end
+    end
 end
 
+function Base.setproperty!(x::Ptr{ImGuiTestItemInfo}, f::Symbol, v)
+    fptr = getproperty(x, f)
+    if fptr isa Ptr
+        unsafe_store!(getproperty(x, f), v)
+    else
+        (baseptr, offset, width) = fptr
+        baseptr32 = convert(Ptr{UInt32}, baseptr)
+        u64 = unsafe_load(baseptr32)
+        straddle = offset + width > 32
+        if straddle
+            u64 |= unsafe_load(baseptr32 + 4) << 32
+        end
+        mask = 1 << width - 1
+        u64 &= ~(mask << offset)
+        u64 |= (unsigned(v) & mask) << offset
+        unsafe_store!(baseptr32, u64 & typemax(UInt32))
+        if straddle
+            unsafe_store!(baseptr32 + 4, u64 >> 32)
+        end
+    end
+end
+
+function Base.propertynames(x::ImGuiTestItemInfo, private::Bool = false)
+    (:ID, :DebugLabel, :Window, :NavLayer, :Depth, :TimestampMain, :TimestampStatus, :ParentID, :RectFull, :RectClipped, :ItemFlags, :StatusFlags, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
 
 struct ImVector_ImGuiTestItemInfo
     Size::Cint
@@ -488,10 +524,34 @@ struct ImVector_ImGuiTestRunTask
 end
 
 struct ImGuiTestInfoTask
-    ID::Cuint
-    FrameCount::Cint
-    DebugName::NTuple{64, Cchar}
-    Result::ImGuiTestItemInfo
+    data::NTuple{168, UInt8}
+end
+
+function Base.getproperty(x::Ptr{ImGuiTestInfoTask}, f::Symbol)
+    f === :ID && return Ptr{Cuint}(x + 0)
+    f === :FrameCount && return Ptr{Cint}(x + 4)
+    f === :DebugName && return Ptr{NTuple{64, Cchar}}(x + 8)
+    f === :Result && return Ptr{ImGuiTestItemInfo}(x + 72)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::ImGuiTestInfoTask, f::Symbol)
+    r = Ref{ImGuiTestInfoTask}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiTestInfoTask}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{ImGuiTestInfoTask}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::ImGuiTestInfoTask, private::Bool = false)
+    (:ID, :FrameCount, :DebugName, :Result, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 struct ImVector_ImGuiTestInfoTask_Ptr
@@ -783,40 +843,9 @@ end
 end
 
 struct ImGuiTestContext
-    GenericVars::ImGuiTestGenericVars
-    UserVars::Ptr{Cvoid}
-    UiContext::Ptr{ImGuiContext}
-    EngineIO::Ptr{ImGuiTestEngineIO}
-    Test::Ptr{ImGuiTest}
-    TestOutput::Ptr{ImGuiTestOutput}
-    OpFlags::Cint
-    PerfStressAmount::Cint
-    FrameCount::Cint
-    FirstTestFrameCount::Cint
-    FirstGuiFrame::Bool
-    HasDock::Bool
-    CaptureArgs::Ptr{ImGuiCaptureArgs}
-    Engine::Ptr{ImGuiTestEngine}
-    Inputs::Ptr{ImGuiTestInputs}
-    RunFlags::Cint
-    ActiveFunc::ImGuiTestActiveFunc
-    RunningTime::Cdouble
-    ActionDepth::Cint
-    CaptureCounter::Cint
-    ErrorCounter::Cint
-    Abort::Bool
-    PerfRefDt::Cdouble
-    PerfIterations::Cint
-    RefStr::NTuple{256, Cchar}
-    RefID::Cuint
-    RefWindowID::Cuint
-    InputMode::ImGuiInputSource
-    TempString::ImVector_char
-    Clipboard::ImVector_char
-    ForeignWindowsToHide::ImVector_ImGuiWindowPtr
-    DummyItemInfoNull::ImGuiTestItemInfo
-    CachedLinesPrintedToTTY::Bool
+    data::NTuple{1312, UInt8}
 end
+
 function Base.getproperty(x::Ptr{ImGuiTestContext}, f::Symbol)
     f === :GenericVars && return Ptr{ImGuiTestGenericVars}(x + 0)
     f === :UserVars && return Ptr{Ptr{Cvoid}}(x + 812)
@@ -850,14 +879,28 @@ function Base.getproperty(x::Ptr{ImGuiTestContext}, f::Symbol)
     f === :Clipboard && return Ptr{ImVector_char}(x + 1188)
     f === :ForeignWindowsToHide && return Ptr{ImVector_ImGuiWindowPtr}(x + 1200)
     f === :DummyItemInfoNull && return Ptr{ImGuiTestItemInfo}(x + 1212)
-    f === :CachedLinesPrintedToTTY && return Ptr{Bool}(x + 1312)
+    f === :CachedLinesPrintedToTTY && return Ptr{Bool}(x + 1308)
     return getfield(x, f)
+end
+
+function Base.getproperty(x::ImGuiTestContext, f::Symbol)
+    r = Ref{ImGuiTestContext}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiTestContext}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
 end
 
 function Base.setproperty!(x::Ptr{ImGuiTestContext}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::ImGuiTestContext, private::Bool = false)
+    (:GenericVars, :UserVars, :UiContext, :EngineIO, :Test, :TestOutput, :OpFlags, :PerfStressAmount, :FrameCount, :FirstTestFrameCount, :FirstGuiFrame, :HasDock, :CaptureArgs, :Engine, :Inputs, :RunFlags, :ActiveFunc, :RunningTime, :ActionDepth, :CaptureCounter, :ErrorCounter, :Abort, :PerfRefDt, :PerfIterations, :RefStr, :RefID, :RefWindowID, :InputMode, :TempString, :Clipboard, :ForeignWindowsToHide, :DummyItemInfoNull, :CachedLinesPrintedToTTY, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
 
 mutable struct ImBuildInfo
     Type::Ptr{Cchar}

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -247,39 +247,75 @@ end
 
 
 struct ImGuiTestItemInfo
-    ID::Cuint
-    DebugLabel::NTuple{32, Cchar}
-    Window::Ptr{ImGuiWindow}
-    NavLayer::Cuint
-    Depth::Cint
-    TimestampMain::Cint
-    TimestampStatus::Cint
-    ParentID::Cuint
-    RectFull::ImRect
-    RectClipped::ImRect
-    ItemFlags::Cint
-    StatusFlags::Cint
+    data::NTuple{104, UInt8}
 end
+
 function Base.getproperty(x::Ptr{ImGuiTestItemInfo}, f::Symbol)
     f === :ID && return Ptr{Cuint}(x + 0)
     f === :DebugLabel && return Ptr{NTuple{32, Cchar}}(x + 4)
     f === :Window && return Ptr{Ptr{ImGuiWindow}}(x + 40)
-    f === :NavLayer && return Ptr{Cuint}(x + 48)
-    f === :Depth && return Ptr{Cint}(x + 52)
-    f === :TimestampMain && return Ptr{Cint}(x + 56)
-    f === :TimestampStatus && return Ptr{Cint}(x + 60)
-    f === :ParentID && return Ptr{Cuint}(x + 64)
-    f === :RectFull && return Ptr{ImRect}(x + 68)
-    f === :RectClipped && return Ptr{ImRect}(x + 84)
-    f === :ItemFlags && return Ptr{Cint}(x + 100)
-    f === :StatusFlags && return Ptr{Cint}(x + 104)
+    f === :NavLayer && return (Ptr{Cuint}(x + 48), 0, 1)
+    f === :Depth && return (Ptr{Cint}(x + 48), 1, 16)
+    f === :TimestampMain && return Ptr{Cint}(x + 52)
+    f === :TimestampStatus && return Ptr{Cint}(x + 56)
+    f === :ParentID && return Ptr{Cuint}(x + 60)
+    f === :RectFull && return Ptr{ImRect}(x + 64)
+    f === :RectClipped && return Ptr{ImRect}(x + 80)
+    f === :ItemFlags && return Ptr{Cint}(x + 96)
+    f === :StatusFlags && return Ptr{Cint}(x + 100)
     return getfield(x, f)
 end
 
-function Base.setproperty!(x::Ptr{ImGuiTestItemInfo}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
+function Base.getproperty(x::ImGuiTestItemInfo, f::Symbol)
+    r = Ref{ImGuiTestItemInfo}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiTestItemInfo}, r)
+    fptr = getproperty(ptr, f)
+    begin
+        if fptr isa Ptr
+            return GC.@preserve(r, unsafe_load(fptr))
+        else
+            (baseptr, offset, width) = fptr
+            ty = eltype(baseptr)
+            baseptr32 = convert(Ptr{UInt32}, baseptr)
+            u64 = GC.@preserve(r, unsafe_load(baseptr32))
+            if offset + width > 32
+                u64 |= GC.@preserve(r, unsafe_load(baseptr32 + 4)) << 32
+            end
+            u64 = u64 >> offset & (1 << width - 1)
+            return u64 % ty
+        end
+    end
 end
 
+function Base.setproperty!(x::Ptr{ImGuiTestItemInfo}, f::Symbol, v)
+    fptr = getproperty(x, f)
+    if fptr isa Ptr
+        unsafe_store!(getproperty(x, f), v)
+    else
+        (baseptr, offset, width) = fptr
+        baseptr32 = convert(Ptr{UInt32}, baseptr)
+        u64 = unsafe_load(baseptr32)
+        straddle = offset + width > 32
+        if straddle
+            u64 |= unsafe_load(baseptr32 + 4) << 32
+        end
+        mask = 1 << width - 1
+        u64 &= ~(mask << offset)
+        u64 |= (unsigned(v) & mask) << offset
+        unsafe_store!(baseptr32, u64 & typemax(UInt32))
+        if straddle
+            unsafe_store!(baseptr32 + 4, u64 >> 32)
+        end
+    end
+end
+
+function Base.propertynames(x::ImGuiTestItemInfo, private::Bool = false)
+    (:ID, :DebugLabel, :Window, :NavLayer, :Depth, :TimestampMain, :TimestampStatus, :ParentID, :RectFull, :RectClipped, :ItemFlags, :StatusFlags, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
 
 struct ImVector_ImGuiTestItemInfo
     Size::Cint
@@ -488,10 +524,34 @@ struct ImVector_ImGuiTestRunTask
 end
 
 struct ImGuiTestInfoTask
-    ID::Cuint
-    FrameCount::Cint
-    DebugName::NTuple{64, Cchar}
-    Result::ImGuiTestItemInfo
+    data::NTuple{176, UInt8}
+end
+
+function Base.getproperty(x::Ptr{ImGuiTestInfoTask}, f::Symbol)
+    f === :ID && return Ptr{Cuint}(x + 0)
+    f === :FrameCount && return Ptr{Cint}(x + 4)
+    f === :DebugName && return Ptr{NTuple{64, Cchar}}(x + 8)
+    f === :Result && return Ptr{ImGuiTestItemInfo}(x + 72)
+    return getfield(x, f)
+end
+
+function Base.getproperty(x::ImGuiTestInfoTask, f::Symbol)
+    r = Ref{ImGuiTestInfoTask}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiTestInfoTask}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
+end
+
+function Base.setproperty!(x::Ptr{ImGuiTestInfoTask}, f::Symbol, v)
+    unsafe_store!(getproperty(x, f), v)
+end
+
+function Base.propertynames(x::ImGuiTestInfoTask, private::Bool = false)
+    (:ID, :FrameCount, :DebugName, :Result, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
 end
 
 struct ImVector_ImGuiTestInfoTask_Ptr
@@ -783,40 +843,9 @@ end
 end
 
 struct ImGuiTestContext
-    GenericVars::ImGuiTestGenericVars
-    UserVars::Ptr{Cvoid}
-    UiContext::Ptr{ImGuiContext}
-    EngineIO::Ptr{ImGuiTestEngineIO}
-    Test::Ptr{ImGuiTest}
-    TestOutput::Ptr{ImGuiTestOutput}
-    OpFlags::Cint
-    PerfStressAmount::Cint
-    FrameCount::Cint
-    FirstTestFrameCount::Cint
-    FirstGuiFrame::Bool
-    HasDock::Bool
-    CaptureArgs::Ptr{ImGuiCaptureArgs}
-    Engine::Ptr{ImGuiTestEngine}
-    Inputs::Ptr{ImGuiTestInputs}
-    RunFlags::Cint
-    ActiveFunc::ImGuiTestActiveFunc
-    RunningTime::Cdouble
-    ActionDepth::Cint
-    CaptureCounter::Cint
-    ErrorCounter::Cint
-    Abort::Bool
-    PerfRefDt::Cdouble
-    PerfIterations::Cint
-    RefStr::NTuple{256, Cchar}
-    RefID::Cuint
-    RefWindowID::Cuint
-    InputMode::ImGuiInputSource
-    TempString::ImVector_char
-    Clipboard::ImVector_char
-    ForeignWindowsToHide::ImVector_ImGuiWindowPtr
-    DummyItemInfoNull::ImGuiTestItemInfo
-    CachedLinesPrintedToTTY::Bool
+    data::NTuple{1376, UInt8}
 end
+
 function Base.getproperty(x::Ptr{ImGuiTestContext}, f::Symbol)
     f === :GenericVars && return Ptr{ImGuiTestGenericVars}(x + 0)
     f === :UserVars && return Ptr{Ptr{Cvoid}}(x + 816)
@@ -850,14 +879,28 @@ function Base.getproperty(x::Ptr{ImGuiTestContext}, f::Symbol)
     f === :Clipboard && return Ptr{ImVector_char}(x + 1232)
     f === :ForeignWindowsToHide && return Ptr{ImVector_ImGuiWindowPtr}(x + 1248)
     f === :DummyItemInfoNull && return Ptr{ImGuiTestItemInfo}(x + 1264)
-    f === :CachedLinesPrintedToTTY && return Ptr{Bool}(x + 1376)
+    f === :CachedLinesPrintedToTTY && return Ptr{Bool}(x + 1368)
     return getfield(x, f)
+end
+
+function Base.getproperty(x::ImGuiTestContext, f::Symbol)
+    r = Ref{ImGuiTestContext}(x)
+    ptr = Base.unsafe_convert(Ptr{ImGuiTestContext}, r)
+    fptr = getproperty(ptr, f)
+    GC.@preserve r unsafe_load(fptr)
 end
 
 function Base.setproperty!(x::Ptr{ImGuiTestContext}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
+function Base.propertynames(x::ImGuiTestContext, private::Bool = false)
+    (:GenericVars, :UserVars, :UiContext, :EngineIO, :Test, :TestOutput, :OpFlags, :PerfStressAmount, :FrameCount, :FirstTestFrameCount, :FirstGuiFrame, :HasDock, :CaptureArgs, :Engine, :Inputs, :RunFlags, :ActiveFunc, :RunningTime, :ActionDepth, :CaptureCounter, :ErrorCounter, :Abort, :PerfRefDt, :PerfIterations, :RefStr, :RefID, :RefWindowID, :InputMode, :TempString, :Clipboard, :ForeignWindowsToHide, :DummyItemInfoNull, :CachedLinesPrintedToTTY, if private
+            fieldnames(typeof(x))
+        else
+            ()
+        end...)
+end
 
 mutable struct ImBuildInfo
     Type::Ptr{Cchar}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -464,10 +464,7 @@ end
         ig.render(ctx; engine) do ; end
     end
 
-    # Errors if the test never ran (Refs unset); compares raw coords so it
-    # doesn't depend on an ImVec2 == method.
-    g, r = imgui_rect[], te_rect[]
-    @test (r[1].x, r[1].y, r[2].x, r[2].y) == (g[1].x, g[1].y, g[2].x, g[2].y)
+    @test te_rect[] == imgui_rect[]
 end
 
 # We only run the Aqua tests in CI because they're kinda slow

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -441,6 +441,35 @@ end
     end
 end
 
+@testset "ItemInfo struct layout" begin
+    # te.ItemInfo and ig.GetItemRectMin/Max query the same widget, so their
+    # rects must agree. A mismatch means the ImGuiTestItemInfo binding's field
+    # offsets disagree with the compiled C++ struct (packed NavLayer:1 / Depth:16).
+    ctx = ig.CreateContext()
+    imgui_rect = Ref{Tuple{ig.ImVec2, ig.ImVec2}}()
+    te_rect = Ref{Tuple{ig.ImVec2, ig.ImVec2}}()
+    do_engine(; exit_on_completion=true) do engine
+        t = @register_test(engine, "Layout", "ItemInfo.RectFull")
+        t.GuiFunc = () -> begin
+            ig.Begin("W")
+            ig.Button("Hi")
+            imgui_rect[] = (ig.GetItemRectMin(), ig.GetItemRectMax())
+            ig.End()
+        end
+        t.TestFunc = () -> begin
+            info = te.ItemInfo("W/Hi")
+            te_rect[] = (info.RectFull.Min, info.RectFull.Max)
+        end
+
+        ig.render(ctx; engine) do ; end
+    end
+
+    # Errors if the test never ran (Refs unset); compares raw coords so it
+    # doesn't depend on an ImVec2 == method.
+    g, r = imgui_rect[], te_rect[]
+    @test (r[1].x, r[1].y, r[2].x, r[2].y) == (g[1].x, g[1].y, g[2].x, g[2].y)
+end
+
 # We only run the Aqua tests in CI because they're kinda slow
 if haskey(ENV, "CI")
     @testset "Aqua.jl" begin


### PR DESCRIPTION
`te.ItemInfo(...)` returned wrong `RectFull`/flags: `ImGuiTestItemInfo` was read with the wrong field offsets because the C++ struct packs `NavLayer : 1` / `Depth : 16` bitfields, making it 104 bytes (the binding assumed 112). Every field from offset 48 on was shifted, so `RectFull` was read 4 bytes off.

Regenerated against `CImGuiPack_jll` 0.12.2 (whose `cimgui_te.h` now carries the bitfields) → correct 104-byte `ImGuiTestItemInfo`, and the structs that embed it by value (`ImGuiTestContext`, `ImGuiTestInfoTask`) get the matching opaque layout. Adds a struct-layout regression test comparing `te.ItemInfo(...).RectFull` to `ig.GetItemRectMin/Max` for the same widget.
